### PR TITLE
Fix broken test due to formatting error

### DIFF
--- a/requirements-development.txt
+++ b/requirements-development.txt
@@ -1,3 +1,4 @@
+black==20.8b1
 freezegun
 pytest
 pytest-black

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -31,14 +31,7 @@ def test_date_field_with_complete_dates(value):
 
 
 @pytest.mark.parametrize(
-    "value",
-    (
-        "2018-07",
-        "Jul/2018",
-        "Jul-2018",
-        "Jul 2018",
-        "07/2018",
-    ),
+    "value", ("2018-07", "Jul/2018", "Jul-2018", "Jul 2018", "07/2018")
 )
 def test_date_field_with_incomplete_dates(value):
     assert DateField.deserialize(value) == date(2018, 7, 1)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -31,7 +31,14 @@ def test_date_field_with_complete_dates(value):
 
 
 @pytest.mark.parametrize(
-    "value", ("2018-07", "Jul/2018", "Jul-2018", "Jul 2018", "07/2018",),
+    "value",
+    (
+        "2018-07",
+        "Jul/2018",
+        "Jul-2018",
+        "Jul 2018",
+        "07/2018",
+    ),
 )
 def test_date_field_with_incomplete_dates(value):
     assert DateField.deserialize(value) == date(2018, 7, 1)


### PR DESCRIPTION
### What
The test `test_date_field_with_incomplete_dates` was failing due to Black format check.

### Details
```shell
.
.
.
tests/test_fields.py F..................                                                                                                                                     [ 94%]
tests/test_main.py s....                                                                                                                                                     [ 99%]
. .                                                                                                                                                                          [100%]

===================================================================================== FAILURES =====================================================================================
________________________________________________________________________________ Black format check ________________________________________________________________________________
--- /home/bruno/Development/calculadora-do-cidadao/tests/test_fields.py	2020-10-12 12:36:02.367622 +0000
+++ /home/bruno/Development/calculadora-do-cidadao/tests/test_fields.py	2020-10-12 12:36:19.619376 +0000
@@ -29,11 +29,18 @@
 def test_date_field_with_complete_dates(value):
     assert DateField.deserialize(value) == date(2018, 7, 6)
 
 
 @pytest.mark.parametrize(
-    "value", ("2018-07", "Jul/2018", "Jul-2018", "Jul 2018", "07/2018",),
+    "value",
+    (
+        "2018-07",
+        "Jul/2018",
+        "Jul-2018",
+        "Jul 2018",
+        "07/2018",
+    ),
 )
 def test_date_field_with_incomplete_dates(value):
     assert DateField.deserialize(value) == date(2018, 7, 1)
.
.
.
```